### PR TITLE
Allow all future Python versions

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -138,7 +138,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "{c,p}p310-*"
+          CIBW_BUILD: "{c,p}p3*"
+          CIBW_SKIP: "{c,p}p3{6..9}-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_24
           CIBW_BEFORE_BUILD: python -m pip install -U pip
@@ -148,7 +149,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "{c,p}p37-* {c,p}p38-* {c,p}p39-*"
+          CIBW_BUILD: "{c,p}p3{7..9}-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_BEFORE_BUILD: python -m pip install -U pip


### PR DESCRIPTION
This PR updates the github actions to build wheels for all current and future versions of Python. This assumes that the code will just work moving forward. It is possible that some additional testing is required to ensure that the built wheels always work.